### PR TITLE
Bug Fixes

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -17,14 +17,17 @@
   ],
   "rules": {
     "comma-dangle": "off",
-    "linebreak-style": 0,
+    "linebreak-style": "off",
+    "max-len": "warn",
     "no-cond-assign": "off",
     "no-console": "off",
-    "no-plusplus": 0,
+    "no-multiple-empty-lines": "warn",
+    "no-plusplus": "off",
     "no-restricted-syntax": "off",
     "no-unused-vars": "warn",
     "no-use-before-define": "off",
     "padded-blocks":"off",
+    "prefer-template": "warn",
     "quotes": [
       "error",
       "double"

--- a/README.md
+++ b/README.md
@@ -38,11 +38,9 @@ npm test
 
 ## Bugs
 
-The updateDeadLink(deadLink) function in replace4chanLinks.js has trouble parsing 4chan links that only have a single digit in their thread / post number. Additionally, if a link is in the format `/{threadNumber}/{words}(optional: postNumber)`, it incorrectly registers any number in {words} part as the postNumber. Finally, 4chan links ending in the format `/{threadNumber},{postNumber}` are not supported.
+To see the links that currently cannot be parsed, view [testCases.json](https://github.com/bzvnr/4chan-Link-Updater/blob/master/lib/testCases.json) replace4chanLinks.specialUseCases.nonFunctional. 4chan links ending in the format `/{threadNumber},{postNumber}` are not supported.
 
 There is no safety check for non-functional links. Use with caution. 
-
-To see the links that currently cannot be parsed, view [testCases.json](https://github.com/bzvnr/4chan-Link-Updater/blob/master/lib/testCases.json) replace4chanLinks.specialUseCases.nonFunctional.
 
 ## Misc. Resources
 

--- a/lib/replace4chanLinks.js
+++ b/lib/replace4chanLinks.js
@@ -51,9 +51,10 @@ function updateDeadLink(deadLink) {
       liveLink = `https://${archiveSite}${boardName}thread/${threadNumber}`;
 
       if (!wordsOrPostNumber && !postNumber) {
+        // only threadNumber
         break;
       } else if (wordsOrPostNumber && !postNumber) {
-        const wordContainsOnlyNumbers = /\d+/.test(wordsOrPostNumber);
+        const wordContainsOnlyNumbers = /^\d+$/.test(wordsOrPostNumber);
 
         if (wordContainsOnlyNumbers) {
           liveLink += `#q${wordsOrPostNumber}`;

--- a/lib/replace4chanLinks.js
+++ b/lib/replace4chanLinks.js
@@ -44,16 +44,23 @@ function updateDeadLink(deadLink) {
   for (const [archiveSite, archiveSiteBoards] of Object.entries(liveSitesAndBoards)) {
 
     if (boardName.match(archiveSiteBoards)) {
-      // exclude single digit numbers [i.e. "4chan", "r9k", "3," etc.]
-      const linkNumbers = [...deadLink.matchAll(/\d{2,}/g)];
+      const match = sitesToReplaceRegex.exec(deadLink);
+      const { threadNumber, wordsOrPostNumber, postNumber } = match.groups;
 
       // [website]/[board]/thread/[threadNumber]
-      liveLink = `https://${archiveSite}${boardName}thread/${linkNumbers[0]}`;
+      liveLink = `https://${archiveSite}${boardName}thread/${threadNumber}`;
 
-      if (linkNumbers.length === 2) {
-        // [website]/[board]/thread/[threadNumber]#q[postNumber]
-        liveLink += `#q${linkNumbers[1]}`;
-      } else if (linkNumbers.length !== 1) {
+      if (!wordsOrPostNumber && !postNumber) {
+        break;
+      } else if (wordsOrPostNumber && !postNumber) {
+        const wordContainsOnlyNumbers = /\d+/.test(wordsOrPostNumber);
+
+        if (wordContainsOnlyNumbers) {
+          liveLink += `#q${wordsOrPostNumber}`;
+        }
+      } else if (postNumber) {
+        liveLink += `#q${postNumber}`;
+      } else {
         return null;
       }
       break;

--- a/lib/replace4chanLinks.test.js
+++ b/lib/replace4chanLinks.test.js
@@ -29,6 +29,15 @@ describe("updateDeadLink(deadLink) with", () => {
     }
   );
 
+  describe("urlPath", () => {
+    test.each(specialUseCases.nonFunctional)(
+      "specialUseCases.nonFunctional",
+      (link) => {
+        testLinkUpdated(link);
+      }
+    );
+  });
+/*
   // specialUseCases.nonFunctional
   describe("urlPath", () => {
     test("in format: /threadNumber}/{words} with a number in {words}", () => {
@@ -55,6 +64,7 @@ describe("updateDeadLink(deadLink) with", () => {
       testLinkUpdated(specialUseCases.nonFunctional[5]);
     });
   });
+  */
 });
 
 describe("getBoardName(deadLink)", () => {

--- a/lib/replace4chanLinks.test.js
+++ b/lib/replace4chanLinks.test.js
@@ -29,7 +29,7 @@ describe("updateDeadLink(deadLink) with", () => {
     }
   );
 
-  describe("urlPath", () => {
+  describe("link", () => {
     test.each(specialUseCases.nonFunctional)(
       "specialUseCases.nonFunctional",
       (link) => {
@@ -37,34 +37,6 @@ describe("updateDeadLink(deadLink) with", () => {
       }
     );
   });
-/*
-  // specialUseCases.nonFunctional
-  describe("urlPath", () => {
-    test("in format: /threadNumber}/{words} with a number in {words}", () => {
-      testLinkUpdated(specialUseCases.nonFunctional[0]);
-    });
-
-    test("in format: /threadNumber}/{words}#p{postNumber} with a number in {words}", () => {
-      testLinkUpdated(specialUseCases.nonFunctional[1]);
-    });
-
-    test("with a single digit in its threadNumber", () => {
-      testLinkUpdated(specialUseCases.nonFunctional[2]);
-    });
-
-    test("with a single digit in its threadNumber and postNumber", () => {
-      testLinkUpdated(specialUseCases.nonFunctional[3]);
-    });
-
-    test("with a board containing a digit and a threadNumber with a single digit", () => {
-      testLinkUpdated(specialUseCases.nonFunctional[4]);
-    });
-
-    test("with a board that is a digit and a threadNumber with a single digit", () => {
-      testLinkUpdated(specialUseCases.nonFunctional[5]);
-    });
-  });
-  */
 });
 
 describe("getBoardName(deadLink)", () => {

--- a/lib/siteAndBoardRegexes.js
+++ b/lib/siteAndBoardRegexes.js
@@ -6,7 +6,7 @@
     a 4chan post could theoretically be formatted: https://4chan.org/3/1/1/1, if the a single-numeral board's post 1 has "1" as the word
 */
 // linkEnding: [boardName]/(thread/)?threadNumber/?(((wordOrPostNumber|-)+)?(/?#?(p|q)?postNumber)?)?
-const linkEnding = /(\/\w+\/)(thread\/)?(?<threadNumber>\d+)(\/)?(((?<wordsOrPostNumber>\w+|-)+)?((\/)?#?(p|q)?(?<postNumber>\d+))?)?/g;
+const linkEnding = /(\/\w+\/)(thread\/)?(?<threadNumber>\d+)(\/)?((?<wordsOrPostNumber>(\w+(-\w+)*))?((\/)?#?(p|q)?(?<postNumber>\d+))?)?/g;
 
 const chanRegex = /(?:boards\.)?(?:4channel|4chan)\.org/;
 const yukiRegex = /yuki\.la/;

--- a/lib/siteAndBoardRegexes.js
+++ b/lib/siteAndBoardRegexes.js
@@ -1,5 +1,12 @@
-// link ending regex: [boardName]/(thread/)?threadNumber/?(((word|-)+)?(/?#?(p|q)?postNumber)?)?
-const linkEnding = /(\/\w+\/)(thread\/)?\d+(\/)?(((\w+|-)+)?((\/)?#?(p|q)?\d+)?)?/g;
+/*
+  link ending regex:
+    captureGroup 1: threadNumber
+    captureGroup 2: wordsOrPostNumber
+    captureGroup 3: postNumber
+    a 4chan post could theoretically be formatted: https://4chan.org/3/1/1/1, if the a single-numeral board's post 1 has "1" as the word
+*/
+// linkEnding: [boardName]/(thread/)?threadNumber/?(((wordOrPostNumber|-)+)?(/?#?(p|q)?postNumber)?)?
+const linkEnding = /(\/\w+\/)(thread\/)?(?<threadNumber>\d+)(\/)?(((?<wordsOrPostNumber>\w+|-)+)?((\/)?#?(p|q)?(?<postNumber>\d+))?)?/g;
 
 const chanRegex = /(?:boards\.)?(?:4channel|4chan)\.org/;
 const yukiRegex = /yuki\.la/;

--- a/lib/siteAndBoardRegexes.js
+++ b/lib/siteAndBoardRegexes.js
@@ -1,8 +1,8 @@
 // link ending regex: [boardName]/(thread/)?threadNumber/?(((word|-)+)?(/?#?(p|q)?postNumber)?)?
-const linkEnding = /\/\w+\/(thread\/)?\d+(\/)?(((\w+|-)+)?((\/)?#?(p|q)?\d+)?)?/g;
+const linkEnding = /(\/\w+\/)(thread\/)?\d+(\/)?(((\w+|-)+)?((\/)?#?(p|q)?\d+)?)?/g;
 
-const chanRegex = /boards(?:\.(4channel|4chan)\.org)/;
-const yukiRegex = /(?:yuki\.la)/;
+const chanRegex = /(?:boards\.)?(?:4channel|4chan)\.org/;
+const yukiRegex = /yuki\.la/;
 const nyafuuRegex = /archive\.nyafuu\.org/;
 const moeArchiveRegex = /archive\.moe/;
 const bStatsRegex = /archive\.b-stats\.org/;
@@ -11,7 +11,7 @@ const desuStorageRegex = /desu-storage\.org/;
 const sitesToReplace = [chanRegex, yukiRegex, nyafuuRegex,
   moeArchiveRegex, bStatsRegex, desuStorageRegex];
 
-const sitesToReplaceRegex = new RegExp(`https?://(www.)?(${chanRegex.source}|${yukiRegex.source}|${nyafuuRegex.source}|${moeArchiveRegex.source}|${bStatsRegex.source}|${desuStorageRegex.source})${linkEnding.source}`);
+const sitesToReplaceRegex = new RegExp(`https?://(?:www.)?(?:${chanRegex.source}|${yukiRegex.source}|${nyafuuRegex.source}|${moeArchiveRegex.source}|${bStatsRegex.source}|${desuStorageRegex.source})${linkEnding.source}`);
 
 const allBoards = /\/(3|a|aco|adv|an|asp|b|bant|biz|c|can|cgl|ck|cm|co|cock|con|d|diy|e|f|fa|fap|fit|fitlit|g|gd|gif|h|hc|his|hm|hr|i|ic|int|jp|k|lgbt|lit|m|mlp|mlpol|mo|mtv|mu|n|news|o|out|outsoc|p|po|pol|pw|q|qa|qb|qst|r|r9k|s|s4s|sci|soc|sp|spa|t|tg|toy|trash|trv|tv|u|v|vg|vint|vip|vm|vmg|vp|vr|vrpg|vst|vt|w|wg|wsg|wsr|x|xs|y)\//;
 

--- a/lib/siteAndBoardRegexes.js
+++ b/lib/siteAndBoardRegexes.js
@@ -28,7 +28,7 @@ const liveSitesAndBoards = {
   "arch.b4k.co": /\/(qb|v|vg|vm|vmg|vp|vrpg|vst)\//, // omitted: g, mlp
   "archive.4plebs.org": /\/(adv|f|hr|o|pol|s4s|sp|tg|trv|tv|x)\//,
   "archive.alice.al": /\/(bant|c|con|e|i|n|news|out|p|pw|qst|toy|vip|vp|vt|w|wg|wsr)\//,
-  "archived.moe": /\/(asp|b|can|cock|fap|fitlit|gd|mlpol|mo|mtv|outsoc|po|spa|vint|xs)\//, // thumbnails only
+  "archived.moe": /\/(asp|b|can|cock|fap|fitlit|gd|mlpol|mo|mtv|outsoc|po|spa|vint|xs)\//, // thumbnails only, except for po and gd which have full images
   "archiveofsins.com": /\/(h|hc|hm|i|lgbt|r|s|soc|t|u)\//,
   "boards.fireden.net": /\/(cm|co|ic|sci|y)\//, // omitted: v. vip
   "desuarchive.org": /\/(a|aco|an|c|cgl|co|d|fit|g|gif|his|int|k|m|mlp|mu|q|qa|r9k|tg|trash|vr|wsg)\//,

--- a/lib/siteAndBoardRegexes.js
+++ b/lib/siteAndBoardRegexes.js
@@ -1,10 +1,3 @@
-/*
-  link ending regex:
-    captureGroup 1: threadNumber
-    captureGroup 2: wordsOrPostNumber
-    captureGroup 3: postNumber
-    a 4chan post could theoretically be formatted: https://4chan.org/3/1/1/1, if the a single-numeral board's post 1 has "1" as the word
-*/
 // linkEnding: [boardName]/(thread/)?threadNumber/?(((wordOrPostNumber|-)+)?(/?#?(p|q)?postNumber)?)?
 const linkEnding = /(\/\w+\/)(thread\/)?(?<threadNumber>\d+)(\/)?((?<wordsOrPostNumber>(\w+(-\w+)*))?((\/)?#?(p|q)?(?<postNumber>\d+))?)?/g;
 

--- a/lib/siteAndBoardRegexes.test.js
+++ b/lib/siteAndBoardRegexes.test.js
@@ -26,3 +26,26 @@ describe("sitesToReplaceRegex", () => {
     }
   );
 });
+
+describe("Test capture groups", () => {
+  test("Only threadNumber", () => {
+    const match = sitesToReplaceRegex.exec("https://4chan.org/3/1");
+    expect(match.groups.threadNumber).toBe("1");
+    expect(match.groups.wordsOrPostNumber).toBeUndefined();
+    expect(match.groups.postNumber).toBeUndefined();
+  });
+
+  test("threadNumber and postNumber", () => {
+    const match = sitesToReplaceRegex.exec("https://4chan.org/3/1/1");
+    expect(match.groups.threadNumber).toBe("1");
+    expect(match.groups.wordsOrPostNumber).toBe("1");
+    expect(match.groups.postNumber).toBeUndefined();
+  });
+
+  test("threadNumber, wordWithNumber, and postNumber", () => {
+    const match = sitesToReplaceRegex.exec("https://4chan.org/3/1/1/1");
+    expect(match.groups.threadNumber).toBe("1");
+    expect(match.groups.wordsOrPostNumber).toBe("1");
+    expect(match.groups.postNumber).toBe("1");
+  });
+});

--- a/lib/testCases.json
+++ b/lib/testCases.json
@@ -74,7 +74,7 @@
         },
         {
           "broken": "https://yuki.la/s4s/3",
-          "fixed": "https://archive.4pleb.org/s4s/thread/3"
+          "fixed": "https://archive.4plebs.org/s4s/thread/3"
         },
         {
           "broken": "https://yuki.la/3/3",

--- a/lib/testCases.json
+++ b/lib/testCases.json
@@ -53,9 +53,7 @@
         {
           "broken": "https://www.yuki.la/s4s/thread/7838249/#q7838249",
           "fixed": "https://archive.4plebs.org/s4s/thread/7838249#q7838249"
-        }
-      ],
-      "nonFunctional": [
+        }, 
         {
           "broken": "https://boards.4channel.org/3/thread/891540/e57-silly-question-about-running-a-program",
           "fixed": "https://warosu.org/3/thread/891540"
@@ -80,6 +78,8 @@
           "broken": "https://yuki.la/3/3",
           "fixed": "https://warosu.org/3/thread/3"
         }
+      ],
+      "nonFunctional": [
       ]
     }
   },

--- a/lib/testCases.json
+++ b/lib/testCases.json
@@ -44,69 +44,77 @@
       "functional": [
         {
           "broken": "https://yuki.la/3/thread/499229",
-          "fixed": "https://warosu.org/3/thread/499229"
+          "fixed": "https://warosu.org/3/thread/499229",
+          "comment": "updating link with boardName as 3"
         },
         {
           "broken": "https://boards.4chan.org/r9k/thread/23675577#p50136909",
-          "fixed": "https://desuarchive.org/r9k/thread/23675577#q50136909"
+          "fixed": "https://desuarchive.org/r9k/thread/23675577#q50136909",
+          "comment": "updating link with boardName as r9k"
+
         },
         {
           "broken": "https://www.yuki.la/s4s/thread/7838249/#q7838249",
-          "fixed": "https://archive.4plebs.org/s4s/thread/7838249#q7838249"
-        }, 
-        {
-          "broken": "https://boards.4channel.org/3/thread/891540/e57-silly-question-about-running-a-program",
-          "fixed": "https://warosu.org/3/thread/891540"
-        },
-        {
-          "broken": "https://boards.4channel.org/3/thread/891540/e57-silly-question-about-running-a-program#p891542",
-          "fixed": "https://warosu.org/3/thread/891540#q891542"
+          "fixed": "https://archive.4plebs.org/s4s/thread/7838249#q7838249",
+          "comment": "updating link with boardName as s4s"
         },
         {
           "broken": "https://yuki.la/vm/thread/1",
-          "fixed": "https://arch.b4k.co/vm/thread/1"
+          "fixed": "https://arch.b4k.co/vm/thread/1",
+          "comment": "updating link with single-digit threadNumber"
         },
         {
           "broken": "https://yuki.la/vm/thread/1/#1",
-          "fixed": "https://arch.b4k.co/vm/thread/1#q1"
-        },
-        {
-          "broken": "https://yuki.la/s4s/3",
-          "fixed": "https://archive.4plebs.org/s4s/thread/3"
+          "fixed": "https://arch.b4k.co/vm/thread/1#q1",
+          "comment": "updating link with single-digit threadNumber and postNumber"
         },
         {
           "broken": "https://yuki.la/3/3",
-          "fixed": "https://warosu.org/3/thread/3"
+          "fixed": "https://warosu.org/3/thread/3",
+          "comment": "updating link with matching single-digit boardName and postNumber"
         },
         {
           "broken": "https://4chan.org/3/1/1/1",
-          "fixed": "https://warosu.org/3/thread/1#q1"
+          "fixed": "https://warosu.org/3/thread/1#q1",
+          "comment": "updating link with matching single-digit threadNumber, word, and postNumber"
         },
         {
-          "broken": "https://4chan.org/s4s/1000/1-1-1-1-1/4000",
-          "fixed": "https://archive.4plebs.org/s4s/thread/1000#q4000"
+          "broken": "https://4chan.org/s4s/1/1-1-1-1-1/1",
+          "fixed": "https://archive.4plebs.org/s4s/thread/1#q1",
+          "comment": "updating link with matching single-digit threadNumber, multiple words, and postNumber"
         },
         {
-          "broken": "https://4channel.org/v/13412141/a1234a-abcd",
-          "fixed": "https://arch.b4k.co/v/thread/13412141"
+          "broken": "https://4chan.org/s4s/1/1-1-1-1-1#1",
+          "fixed": "https://archive.4plebs.org/s4s/thread/1#q1",
+          "comment": "updating link with matching single-digit threadNumber, multiple words, and postNumber"
         },
         {
-          "broken": "https://4channel.org/v/13412141/a1234a",
-          "fixed": "https://arch.b4k.co/v/thread/13412141"
+          "broken": "https://4channel.org/v/1/a1234a",
+          "fixed": "https://arch.b4k.co/v/thread/1",
+          "comment": "updating link with word containing numbers"
         },
+        {
+          "broken": "https://4channel.org/v/1/a1234a-abcd",
+          "fixed": "https://arch.b4k.co/v/thread/1",
+          "comment": "updating link with word containing numbers and another word"
+        },
+
         {
           "broken": "https://4channel.org/v/13412141/a1234a-a5678a",
-          "fixed": "https://arch.b4k.co/v/thread/13412141"
+          "fixed": "https://arch.b4k.co/v/thread/13412141",
+          "comment": "updating link with multiple word containing numbers"
         },
         {
           "broken": "https://4channel.org/v/13412141/1234-5678",
-          "fixed": "https://arch.b4k.co/v/thread/13412141"
+          "fixed": "https://arch.b4k.co/v/thread/13412141",
+          "comment": "updating link with multiple words that are numbers"
         }
       ],
       "nonFunctional": [
         {
-          "broken": "https://4channel.org/v/13412141/43110",
-          "fixed": "https://arch.b4k.co/v/thread/13412141"
+          "broken": "https://4channel.org/v/13412141/1234",
+          "fixed": "https://arch.b4k.co/v/thread/13412141",
+          "comment": "updating link with a word that is a number"
         }
       ]
     }

--- a/lib/testCases.json
+++ b/lib/testCases.json
@@ -77,9 +77,33 @@
         {
           "broken": "https://yuki.la/3/3",
           "fixed": "https://warosu.org/3/thread/3"
+        },
+        {
+          "broken": "https://4chan.org/3/1/1/1",
+          "fixed": "https://warosu.org/3/thread/1#q1"
+        },
+        {
+          "broken": "https://4chan.org/s4s/1000/1-1-1-1-1/4000",
+          "fixed": "https://archive.4plebs.org/s4s/thread/1000#q4000"
+        },
+        {
+          "broken": "https://4channel.org/v/13412141/a1234a-abcd",
+          "fixed": "https://arch.b4k.co/v/thread/13412141"
         }
       ],
       "nonFunctional": [
+        {
+          "broken": "https://4channel.org/v/13412141/a1234a",
+          "fixed": "https://arch.b4k.co/v/thread/13412141"
+        },
+        {
+          "broken": "https://4channel.org/v/13412141/a1234a-a5678a",
+          "fixed": "https://arch.b4k.co/v/thread/13412141"
+        },
+        {
+          "broken": "https://4channel.org/v/13412141/1234-5678",
+          "fixed": "https://arch.b4k.co/v/thread/13412141"
+        }
       ]
     }
   },

--- a/lib/testCases.json
+++ b/lib/testCases.json
@@ -89,9 +89,7 @@
         {
           "broken": "https://4channel.org/v/13412141/a1234a-abcd",
           "fixed": "https://arch.b4k.co/v/thread/13412141"
-        }
-      ],
-      "nonFunctional": [
+        },
         {
           "broken": "https://4channel.org/v/13412141/a1234a",
           "fixed": "https://arch.b4k.co/v/thread/13412141"
@@ -104,6 +102,8 @@
           "broken": "https://4channel.org/v/13412141/1234-5678",
           "fixed": "https://arch.b4k.co/v/thread/13412141"
         }
+      ],
+      "nonFunctional": [
       ]
     }
   },

--- a/lib/testCases.json
+++ b/lib/testCases.json
@@ -86,6 +86,15 @@
   "sitesAndBoardRegexes": {
     "typicalUseCases": [
       {
+        "url": "https://4chan.org/vm/thread/1"
+      },
+      {
+        "url": "https://boards.4channel.org/vm/thread/1"
+      },
+      {
+        "url": "https://4channel.org/vm/thread/1"
+      },
+      {
         "url": "https://yuki.la/vm/thread/1"
       },
       {

--- a/lib/testCases.json
+++ b/lib/testCases.json
@@ -104,6 +104,10 @@
         }
       ],
       "nonFunctional": [
+        {
+          "broken": "https://4channel.org/v/13412141/43110",
+          "fixed": "https://arch.b4k.co/v/thread/13412141"
+        }
       ]
     }
   },

--- a/lib/updateLinks.js
+++ b/lib/updateLinks.js
@@ -1,4 +1,4 @@
-const chanLinkUpdater = require("./replace4chanLinks.js");
+const chanLinkUpdater = require("./replace4chanLinks");
 
 const myText = ""; // place your text between the ""
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "4chan-link-updater",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "4chan-link-updater",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "Update dead/broken 4chan and 4chan archive links with live links. Contains Regex for 4chan archive sites and all boards.",
   "keywords": [
     "4chan",


### PR DESCRIPTION
Tests: 80/81 passing
- siteAndBoardRegexes.js
  - added named capture groups to linkEnding regex: threadNumber, wordOrPostNumber, and postNumber
  - test.js: added tests for capturing the named capture groups
- replace4chanLinks.js
  - updated to use named capture groups
  - test.js: simplified
- testCases.json
  - moved fixed non-functional cases to functional
  - removed some redundant tests
  - added new test cases
  - added comments to replace4chanLinks.specialUseCases
- eslintrc.json
  - changed numbers to words
- updateLinks.js
  - fixed import error
